### PR TITLE
fixed NPE due to null canvas

### DIFF
--- a/signature-view/src/main/java/se/warting/signatureview/views/SignaturePad.kt
+++ b/signature-view/src/main/java/se/warting/signatureview/views/SignaturePad.kt
@@ -503,7 +503,7 @@ class SignaturePad(context: Context, attrs: AttributeSet?) : View(context, attrs
 
             // Set the incremental stroke width and draw.
             mPaint.strokeWidth = startWidth + ttt * widthDelta
-            mSignatureBitmapCanvas!!.drawPoint(x, y, mPaint)
+            mSignatureBitmapCanvas?.drawPoint(x, y, mPaint)
             i++
         }
         mPaint.strokeWidth = originalWidth


### PR DESCRIPTION
Tracked by [ABCD-XXXX](https://github.com/warting/android-signaturepad/issues/ABCD-XXXX)

## This PR...

Aims to resolve NPE caused due to null canvas in addBezier method

## Considerations and implementation

_What technical details should the team pay particular attention to? What unexpected issues did you encounter?_

### How to test

No reproducible method found. Appears to be happening on API level 28 and below.

### Test(s) added 

_Why did you add tests around the areas you did? If none, explain why_

### Screenshots

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |
